### PR TITLE
Add missing JSTDBY_OSC port connection.

### DIFF
--- a/MachXO2/tiledata/CIB_CFG0/bits.db
+++ b/MachXO2/tiledata/CIB_CFG0/bits.db
@@ -2607,5 +2607,9 @@ V06S0303 F21B8 F23B10
 
 .fixed_conn JQ5 G_JOSC_OSC
 
+.fixed_conn JSTDBY_OSC JLSR1
+
+.fixed_conn SEDSTDBY_OSC JSTDBY_OSC
+
 .fixed_conn W2_JREFCLK0 G_JOSC_OSC
 


### PR DESCRIPTION
Please merge by fast-forward, as my `prjtrellis` fork already points to this commit.

This was a big oversight. Without this fuzzing, using the OSCH won't work at all- nextpnr will fail to find a route :D!